### PR TITLE
Rename blob to body, update to newest zcap invoke.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalcredentials/ezcap Changelog
 
+## 6.0.0 -
+### Changed
+- **BREAKING**: Rename `blob` payload param to `body` to match upstream
+  PR https://github.com/digitalbazaar/http-signature-zcap-invoke/pull/30/
+- **BREAKING**: By default, set the `action` to be the same as the http `method`.
+
 ## 5.1.0 - 2025-09-03
 ### Added
 - Add support for binary `blob` objects to `request()`.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ const response = await zcapClient.write({capability, json: item});
 const writtenItem = await response.json();
 ```
 
+### Requesting with a non-JSON binary blob body
+
+```js
+const body = new Blob(['line 1\nline2\n'], {type: 'text/plain'})
+await zcapClient.request({
+  url, method: 'POST', body
+})
+```
+
 ### Requesting with a Root Capability
 
 In the event that the server API does not operate using HTTP GET and HTTP POST,

--- a/lib/ZcapClient.js
+++ b/lib/ZcapClient.js
@@ -299,8 +299,8 @@ export class ZcapClient {
   async request({
     url,
     capability,
-    method = 'get',
-    action = 'read',
+    method = 'GET',
+    action,
     headers = {},
     json,
     body
@@ -308,6 +308,8 @@ export class ZcapClient {
     if(!this.invocationSigner) {
       throw new Error('"invocationSigner" was not provided in constructor.');
     }
+    // By default, set the action to be the same as the HTTP method if missing
+    action = action || method;
 
     // get invocation target from zcap
     let invocationTarget;

--- a/lib/ZcapClient.js
+++ b/lib/ZcapClient.js
@@ -291,7 +291,7 @@ export class ZcapClient {
    *   send along with the HTTP request. Default: {}.
    * @param {object} [options.json] - The JSON object, if any, to send with the
    *   request.
-   * @param {Blob|Buffer|Uint8Array} [options.blob] - The binary blob to send
+   * @param {Blob|Buffer|Uint8Array} [options.body] - A non-JSON blob to send
    *   with the request (for file uploads, PDFs, images, etc.).
    *
    * @returns {Promise<object>} - A promise that resolves to an HTTP response.
@@ -303,7 +303,7 @@ export class ZcapClient {
     action = 'read',
     headers = {},
     json,
-    blob
+    body
   } = {}) {
     if(!this.invocationSigner) {
       throw new Error('"invocationSigner" was not provided in constructor.');
@@ -370,6 +370,7 @@ export class ZcapClient {
         date: new Date().toUTCString()
       },
       json,
+      body,
       invocationSigner,
       capability: capability || await generateZcapUri({url}),
       capabilityAction: action
@@ -383,8 +384,8 @@ export class ZcapClient {
     };
 
     // handle blob vs json body
-    if(blob !== undefined) {
-      options.body = blob;
+    if(body !== undefined) {
+      options.body = body;
     } else if(json !== undefined) {
       options.json = json;
     }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@digitalcredentials/http-client": "^5.0.4",
-    "@digitalbazaar/http-signature-zcap-invoke": "^6.0.0",
-    "@digitalbazaar/zcap": "^9.0.0",
+    "@digitalbazaar/http-signature-zcap-invoke": "^6.1.0",
+    "@digitalbazaar/zcap": "^9.0.1",
     "@digitalcredentials/jsonld-signatures": "^12.0.1",
     "uuid": "^9.0.1"
   },

--- a/tests/unit/EzcapClient.spec.js
+++ b/tests/unit/EzcapClient.spec.js
@@ -160,7 +160,7 @@ describe('ZcapClient', () => {
         await zcapClient.request({
           url: 'https://zcap.example/items',
           method: 'post',
-          blob
+          body: blob
         });
       } catch(e) {
         error = e;
@@ -192,7 +192,7 @@ describe('ZcapClient', () => {
           url: 'https://zcap.example/items',
           method: 'post',
           json,
-          blob
+          body: blob
         });
       } catch(e) {
         error = e;
@@ -220,7 +220,7 @@ describe('ZcapClient', () => {
       try {
         await zcapClient.write({
           url: 'https://zcap.example/items',
-          blob
+          body: blob
         });
       } catch(e) {
         error = e;


### PR DESCRIPTION
Rename `blob` payload param to `body` to match upstream PR https://github.com/digitalbazaar/http-signature-zcap-invoke/pull/30/